### PR TITLE
add Civilian Ships clipper and dinghy to game

### DIFF
--- a/src/main/java/edu/oregonstate/cs361/battleship/BattleshipModel.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/BattleshipModel.java
@@ -14,12 +14,16 @@ public class BattleshipModel {
     private Ship cruiser = new Ship("Cruiser",3, new Coordinate(0,0),new Coordinate(0,0));
     private Ship destroyer = new Ship("Destroyer",2, new Coordinate(0,0),new Coordinate(0,0));
     private Ship submarine = new Ship("Submarine",2, new Coordinate(0,0),new Coordinate(0,0));
+    private Civilian clipper = new Civilian("Clipper", 3, new Coordinate(0, 0), new Coordinate(0, 0));
+    private Civilian dinghy = new Civilian("Dinghy", 1, new Coordinate(0, 0), new Coordinate(0, 0));
 
     private Ship computer_aircraftCarrier = new Ship("Computer_AircraftCarrier",5, new Coordinate(2,2),new Coordinate(2,6));
     private Ship computer_battleship = new Ship("Computer_Battleship",4, new Coordinate(2,8),new Coordinate(5,8));
     private Ship computer_cruiser = new Ship("Computer_Cruiser",3, new Coordinate(4,1),new Coordinate(4,3));
     private Ship computer_destroyer = new Ship("Computer_Destroyer",2, new Coordinate(7,3),new Coordinate(7,4));
     private Ship computer_submarine = new Ship("Computer_Submarine",2, new Coordinate(9,6),new Coordinate(9,7));
+    private Civilian computer_clipper = new Civilian("Computer_Clipper", 3, new Coordinate(5, 1), new Coordinate(5, 3));
+    private Civilian computer_dinghy = new Civilian("Computer_Dinghy", 1, new Coordinate(10, 10), new Coordinate(10, 10));
 
     ArrayList<Coordinate> playerHits;
     private ArrayList<Coordinate> playerMisses;
@@ -54,6 +58,10 @@ public class BattleshipModel {
             return destroyer;
         }if(shipName.equalsIgnoreCase("submarine")) {
             return submarine;
+        }if(shipName.equalsIgnoreCase("clipper")) {
+            return clipper;
+        }if(shipName.equalsIgnoreCase("dinghy")) {
+            return dinghy;
         } else {
             return null;
         }
@@ -89,6 +97,10 @@ public class BattleshipModel {
                 this.getShip(shipName).setLocation(new Coordinate(rowint,colInt),new Coordinate(rowint,colInt+1));
             }if(shipName.equalsIgnoreCase("submarine")) {
                 this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint, colInt+1));
+            }if(shipName.equalsIgnoreCase("clipper")) {
+                this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint, colInt+2));
+            }if(shipName.equalsIgnoreCase("dinghy")) {
+                this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint, colInt));
             }
         }else{
             //vertical
@@ -100,8 +112,12 @@ public class BattleshipModel {
                     this.getShip(shipName).setLocation(new Coordinate(rowint,colInt),new Coordinate(rowint+2,colInt));
                 } if(shipName.equalsIgnoreCase("destroyer")) {
                     this.getShip(shipName).setLocation(new Coordinate(rowint,colInt),new Coordinate(rowint+1,colInt));
-                }if(shipName.equalsIgnoreCase("submarine")) {
+                } if(shipName.equalsIgnoreCase("submarine")) {
                     this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint + 1, colInt));
+                } if(shipName.equalsIgnoreCase("clipper")) {
+                    this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint+2, colInt));
+                } if(shipName.equalsIgnoreCase("dinghy")) {
+                    this.getShip(shipName).setLocation(new Coordinate(rowint, colInt), new Coordinate(rowint, colInt));
                 }
         }
 
@@ -144,6 +160,10 @@ public class BattleshipModel {
             computerHits.add(coor);
         }else if (computer_submarine.covers(coor)){
             computerHits.add(coor);
+        }else if (computer_clipper.covers(coor)){
+            computerHits.addAll(computer_clipper.one_hit());
+        }else if (computer_dinghy.covers(coor)){
+            computerHits.addAll(computer_dinghy.one_hit());
         } else {
             computerMisses.add(coor);
         }
@@ -175,6 +195,10 @@ public class BattleshipModel {
             playerHits.add(coor);
         }else if (submarine.covers(coor)){
             playerHits.add(coor);
+        }else if (clipper.covers(coor)){
+            playerHits.addAll(clipper.one_hit());
+        }else if (dinghy.covers(coor)){
+            playerHits.addAll(dinghy.one_hit());
         } else {
             playerMisses.add(coor);
         }
@@ -194,6 +218,10 @@ public class BattleshipModel {
         }else if (computer_destroyer.scan(coor)){
             scanResult = true;
         }else if (computer_submarine.scan(coor)){
+            scanResult = true;
+        }else if (computer_clipper.scan(coor)){
+            scanResult = true;
+        }else if (computer_dinghy.scan(coor)) {
             scanResult = true;
         } else {
             scanResult = false;

--- a/src/main/java/edu/oregonstate/cs361/battleship/BattleshipModel.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/BattleshipModel.java
@@ -45,17 +45,17 @@ import java.util.Random;
     }
 
 
-    public Military getShip(String shipName) {
+    public Ship getShip(String shipName) {
         if (shipName.equalsIgnoreCase("aircraftcarrier")) {
-            return aircraftCarrier;
+            return this.aircraftCarrier;
         } if(shipName.equalsIgnoreCase("battleship")) {
-            return battleship;
+            return this.battleship;
         } if(shipName.equalsIgnoreCase("submarine")) {
-            return submarine;
+            return this.submarine;
         }if(shipName.equalsIgnoreCase("clipper")) {
-            return clipper;
+            return this.clipper;
         }if(shipName.equalsIgnoreCase("dinghy")) {
-            return dinghy;
+            return this.dinghy;
         } else {
             return null;
         }

--- a/src/main/java/edu/oregonstate/cs361/battleship/Civilian.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/Civilian.java
@@ -4,6 +4,11 @@ import java.util.ArrayList;
 
 
 public class Civilian extends Ship {
+
+    public Civilian(String n, int l, Coordinate s, Coordinate e) {
+        super(n, l, s, e);
+    }
+
     ArrayList <Coordinate> one_hit() {
         return this.getShipSquares();
     }

--- a/src/main/java/edu/oregonstate/cs361/battleship/Civilian.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/Civilian.java
@@ -1,0 +1,10 @@
+package edu.oregonstate.cs361.battleship;
+
+import java.util.ArrayList;
+
+
+public class Civilian extends Ship {
+    ArrayList <Coordinate> one_hit() {
+        return this.getShipSquares();
+    }
+}

--- a/src/main/java/edu/oregonstate/cs361/battleship/Ship.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/Ship.java
@@ -11,6 +11,8 @@ public class Ship {
     private Coordinate start;
     private Coordinate end;
 
+    public Ship() {}
+
     public Ship(String n, int l,Coordinate s, Coordinate e) {
         name = n;
         length = l;

--- a/src/main/java/edu/oregonstate/cs361/battleship/Ship.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/Ship.java
@@ -21,7 +21,6 @@ public class Ship {
 
     }
 
-    public Ship() {}
 
     public Ship(String n, int l,Coordinate s, Coordinate e) {
         name = n;


### PR DESCRIPTION
Satisfies #2 and #3 

## Changes this PR introduces
- [X] explicitly specifies ``Ship`` default constructor (alternative method proposed by @kbajno's #10)
- [X] creates new subclass ``Civilian`` that inherits off of ``Ship``; ``Civilian`` is special type of ``Ship`` since it has a ``one_hit`` sink method
- [X] adds ``Civilian`` ships ``dinghy`` and ``clipper`` to the game
- [X] ^^^ modify ``shootAt`` methods so that the above ships sink in one hit

## To test this PR
- clone fork
- run main
- **fire at computer's clipper: 5,1 or 5,2 or 5,3. For any of these coordinates, the other two should also get hit.**
- fire at computer's dinghy: 10,10.
- test that all other functionality (besides placing clipper and dinghy) still works as expected

## Notes
These existing tests currently fail: 
```
testGetModel()
testPlaceShip()
testScan()
```
TODO: Tests (fix existing and write new) + frontend modifications to place these new ships. See #8 and #9 