### PR TITLE
change stealth to be public

### DIFF
--- a/src/main/java/edu/oregonstate/cs361/battleship/Military.java
+++ b/src/main/java/edu/oregonstate/cs361/battleship/Military.java
@@ -5,7 +5,7 @@ package edu.oregonstate.cs361.battleship;
  */
 
 public class Military extends Ship {
-    private boolean stealth;
+    boolean stealth;
 
     public Military(boolean b, String n, int l,Coordinate s, Coordinate e) {
         super(n,l,s,e);


### PR DESCRIPTION
Alternative fix to #12. Either merge this PR or #12; not both.

## Changes
- [X] ``Military``'s ``stealth`` attribute is now public instead of private

## Test
- clone repo
- run main
- place aircraftcarrier, submarine, battleship; all three should stay on board
- fire at computer: expected behavior